### PR TITLE
fix eslint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,8 +1,9 @@
-parser: "babel-eslint"
 env:
   browser: true
   es6: true
   node: true
+parserOptions:
+  ecmaVersion: 2017
 extends:
   - 'eslint:recommended'
 rules:

--- a/package.json
+++ b/package.json
@@ -1,29 +1,28 @@
 {
-    "name": "carauction",
-    "version": "1.0.0",
-    "description": "Hyperledger Fabric Car Sample Application",
-    "main": "carauction.js",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "lint": "./node_modules/.bin/eslint . ./**/*.js"
-    },
-    "dependencies": {
-        "fabric-ca-client": "unstable",
-        "fabric-client": "unstable",
-        "grpc": "^1.6.0"
-    },
-    "devDependencies": {
-        "babel-eslint": "^9.0.0",
-        "eslint": "^4.13.1",
-        "eslint-plugin-react": "^7.9.1"
-    },
-    "author": "Horea Porutiu",
-    "license": "Apache-2.0",
-    "keywords": [
-        "Hyperledger",
-        "Fabric",
-        "Car",
-        "Sample",
-        "Application"
-    ]
+  "name": "carauction",
+  "version": "1.0.0",
+  "description": "Hyperledger Fabric Car Sample Application",
+  "main": "carauction.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "fabric-ca-client": "unstable",
+    "fabric-client": "unstable",
+    "grpc": "^1.6.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-react": "^7.9.1"
+  },
+  "author": "Horea Porutiu",
+  "license": "Apache-2.0",
+  "keywords": [
+    "Hyperledger",
+    "Fabric",
+    "Car",
+    "Sample",
+    "Application"
+  ]
 }


### PR DESCRIPTION
- fix broken-on-Windows command in npm "lint" script
- remove unnecessary module babel-eslint
- specify ECMAScript version 2017 in .eslintrc.yml